### PR TITLE
[CE3] Fork gh-action-nightly-merge and fix it (for now)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
-LABEL repository="http://github.com/robotology/gh-action-nightly-merge"
-LABEL homepage="http://github.com/robotology/gh-action-nightly-merge"
+LABEL repository="http://github.com/usertesting/gh-action-nightly-merge"
+LABEL homepage="http://github.com/usertesting/gh-action-nightly-merge"
 LABEL "com.github.actions.name"="Nightly Merge"
 LABEL "com.github.actions.description"="Automatically merge the stable branch into the development one."
 LABEL "com.github.actions.icon"="git-merge"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,14 @@ if [[ "$INPUT_ALLOW_FF" == "true" ]]; then
   fi
 fi
 
+# Change based from:
+# * https://github.com/robotology/gh-action-nightly-merge/compare/master...tModLoader:master#
+# * https://github.com/actions/checkout/issues/766
+# * https://github.com/robotology/gh-action-nightly-merge/issues/11#issuecomment-1100451815
+# * (docs) https://git-scm.com/docs/git-config
+# * (GITHUB_WORKSPACE) https://docs.github.com/en/actions/learn-github-actions/environment-variables
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
 git remote set-url origin https://x-access-token:${!INPUT_PUSH_TOKEN}@github.com/$GITHUB_REPOSITORY.git
 git config --global user.name "$INPUT_USER_NAME"
 git config --global user.email "$INPUT_USER_EMAIL"


### PR DESCRIPTION
# Purpose
Hopefully we won't need to use the fork for too long, but the solution is fairly simple (I'll PR the upstream repo once I have this working successfully internally). In the short term though, let's work around the git permissions change by specifically allowing the GITHUB_WORKSPACE to be accessed as a shared repository, as suggested in https://github.com/actions/checkout/issues/766

# Ticket
Part of the fix for [CTI-1624](https://user-testing.atlassian.net/browse/CTI-1624)

# Implementation
* Fork the upstream repository (https://github.com/robotology/gh-action-nightly-merge)
* Update the main entrypoint script to add `$GITHUB_WORKSPACE` as a 'safe' directory for access/use
* Update the dockerfile to point to the fork instead of the parent.

I've verified that it performs successfully via the `CTI-1624--fix-nightly-merge--target` branch and the `CTI-1624--fix-nightly-merge--trial` branch on orders: https://github.com/usertesting/orders/actions/runs/2184582580

(PR for the upstream, so we can drop the fork, is [here](https://github.com/robotology/gh-action-nightly-merge/pull/13))